### PR TITLE
Upgrade pip to 8.1.2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,7 +43,7 @@ default['python']['pip_location'] = "#{node['python']['prefix_dir']}/bin/pip"
 default['python']['virtualenv_location'] = "#{node['python']['prefix_dir']}/bin/virtualenv"
 default['python']['setuptools_version'] = "7.0" # defaults to latest
 default['python']['distribute_version'] = "0.7.3"
-default['python']['pip_version'] = "1.5.6"
+default['python']['pip_version'] = "8.1.2"
 case platform_version
 when "16.04"
     override['python']['virtualenv_version'] = '15.0.2'

--- a/providers/virtualenv.rb
+++ b/providers/virtualenv.rb
@@ -56,7 +56,7 @@ action :create do
     user new_resource.owner if new_resource.owner
     group new_resource.group if new_resource.group
     action :install
-    version "1.5.6"
+    version node['python']['pip_version']
     virtualenv new_resource.path
   end
 

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -54,5 +54,5 @@ end
 
 python_pip 'pip' do
   action :install
-  version "1.5.6"
+  version node['python']['pip_version']
 end


### PR DESCRIPTION
I tested this upgrade in Ubuntu 14.04 and it worked as I expected.

On Ubuntu 16.04 we can't install data product on existing machines and this PR doesn't fix it. We need to either terminate the running 16.04 machines or delete their app virtualenv folders. I would terminate the machines.


This PR depends on https://github.com/yipit-cookbooks/yipit_apps/pull/71

Review please, @andrewgross, @spulec, @mateusdelbianco 


yipit_logstash is next.