### PR TITLE
Add support to Chef 13

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,8 +20,8 @@
 
 default['python']['install_method'] = 'package'
 
-if python['install_method'] == 'package'
-  case platform
+if node['python']['install_method'] == 'package'
+  case node['platform']
   when "smartos"
     default['python']['prefix_dir']         = '/opt/local'
   else

--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -100,7 +100,7 @@ end
 # so refactoring into core Chef should be easy
 
 def load_current_resource
-  @current_resource = Chef::Resource::PythonPip.new(new_resource.name)
+  @current_resource = Chef::Resource.resource_for_node(:python_pip, node).new(new_resource.name)
   @current_resource.package_name(new_resource.package_name)
   @current_resource.version(nil)
 

--- a/providers/virtualenv.rb
+++ b/providers/virtualenv.rb
@@ -73,7 +73,7 @@ action :delete do
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::PythonVirtualenv.new(new_resource.name)
+  @current_resource = Chef::Resource::resource_for_node(:python_virtualenv, node).new(new_resource.name)
   @current_resource.path(new_resource.path)
 
   if exists?


### PR DESCRIPTION
Chef 13 dropped support for attribute shortcuts like `foo` instead of `node['foo']`. It's also no longer possible to reference a resource via its class name (`Chef::Resource::PythonPip` vs `Chef::Resource.resource_for_node(:python_pip, node)`, see https://github.com/RoboticCheese/dmg/commit/df21e33bf03228ab7bd09939b0dec76d3ab556a0 commit message).